### PR TITLE
tasks: run restart hooks with bash -lc

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -182,17 +182,17 @@ class RunRestartHooksTest(TestCase):
         }}}
         run_restart_hooks('before', data, envs={'env': 'varrr'})
         self.assertEqual(popen_call.call_count, 2)
-        self.assertEqual(popen_call.call_args_list[0][0][0], 'b2')
-        self.assertEqual(popen_call.call_args_list[0][1]['shell'], True)
+        self.assertEqual(popen_call.call_args_list[0][0][0], ['/bin/bash', '-lc', 'b2'])
+        self.assertEqual(popen_call.call_args_list[0][1]['shell'], False)
         self.assertEqual(popen_call.call_args_list[0][1]['cwd'], '/')
         self.assertEqual(popen_call.call_args_list[0][1]['env'], {'env': 'varrr',
                                                                   'env1': 'var1'})
-        self.assertEqual(popen_call.call_args_list[1][0][0], 'b1')
+        self.assertEqual(popen_call.call_args_list[1][0][0], ['/bin/bash', '-lc', 'b1'])
         wait_mock.assert_any_call()
         run_restart_hooks('after', data)
         self.assertEqual(popen_call.call_count, 4)
-        self.assertEqual(popen_call.call_args_list[3][0][0], 'a1')
-        self.assertEqual(popen_call.call_args_list[2][0][0], 'a2')
+        self.assertEqual(popen_call.call_args_list[3][0][0], ['/bin/bash', '-lc', 'a1'])
+        self.assertEqual(popen_call.call_args_list[2][0][0], ['/bin/bash', '-lc', 'a2'])
 
     @mock.patch("tsuru_unit_agent.tasks.Stream")
     @mock.patch("os.environ", {'env': 'var', 'env1': 'var1'})
@@ -210,8 +210,8 @@ class RunRestartHooksTest(TestCase):
         run_restart_hooks('before', data, envs={'env': 'varrr'})
         self.assertEqual(os.environ, {'env': 'var', 'env1': 'var1'})
         self.assertEqual(popen_call.call_count, 1)
-        self.assertEqual(popen_call.call_args_list[0][0][0], 'b1')
-        self.assertEqual(popen_call.call_args_list[0][1]['shell'], True)
+        self.assertEqual(popen_call.call_args_list[0][0][0], ['/bin/bash', '-lc', 'b1'])
+        self.assertEqual(popen_call.call_args_list[0][1]['shell'], False)
         self.assertEqual(popen_call.call_args_list[0][1]['cwd'], '/')
         self.assertEqual(popen_call.call_args_list[0][1]['env'], {'env': 'varrr',
                                                                   'env1': 'var1'})

--- a/tsuru_unit_agent/tasks.py
+++ b/tsuru_unit_agent/tasks.py
@@ -94,18 +94,21 @@ def execute_start_script(start_cmd, envs=None, with_shell=True):
     exec_with_envs([start_cmd], with_shell=with_shell, envs=envs)
 
 
+def execute_hooks_scripts(hook_cmd_list, envs=None, with_shell=True, pipe_output=False):
+    commands = [["/bin/bash", "-lc", cmd] for cmd in hook_cmd_list]
+    exec_with_envs(commands, with_shell=with_shell, envs=envs, pipe_output=pipe_output)
+
+
 def run_build_hooks(app_data, envs=None):
     commands = (app_data.get('hooks') or {}).get('build') or []
-    commands = [["/bin/bash", "-lc", cmd] for cmd in commands]
-    exec_with_envs(commands, with_shell=False, envs=envs)
+    execute_hooks_scripts(commands, with_shell=False, envs=envs)
 
 
 def run_restart_hooks(position, app_data, envs=None):
     restart_hook = (app_data.get('hooks') or {}).get('restart') or {}
     commands = restart_hook.get('{}-each'.format(position)) or []
     commands += restart_hook.get(position) or []
-    exec_with_envs(commands, with_shell=True, pipe_output=True,
-                   envs=envs)
+    execute_hooks_scripts(commands, with_shell=False, envs=envs, pipe_output=True)
 
 
 def load_app_yaml(working_dir="/home/application/current"):


### PR DESCRIPTION
This guarantees the app's environment variables being available for the hooks.
